### PR TITLE
[PR#1] ios18 album sandbox

### DIFF
--- a/LiveFourCut/LiveFourCut/Views/PhotoSelectionScene/PhotoSelectionViewController.swift
+++ b/LiveFourCut/LiveFourCut/Views/PhotoSelectionScene/PhotoSelectionViewController.swift
@@ -46,7 +46,7 @@ final class PhotoSelectionViewController: LoadingVC{
     override func viewDidLoad() {
         super.viewDidLoad()
         Task{
-            thumbnailExecutor.thumbnailsSubject
+            await thumbnailExecutor.thumbnailsSubject
                 .receive(on: RunLoop.main)
                 .sink {[weak self] containers in
                     self?.thumbnailSelectorView.imageContainers = containers
@@ -58,7 +58,7 @@ final class PhotoSelectionViewController: LoadingVC{
                     self?.reSelectPhotoBtn.isHidden = !pagingAvailable
                     self?.isPagingEnabled = pagingAvailable
                 }.store(in: &cancellable)
-            thumbnailExecutor.progressSubject.receive(on: RunLoop.main)
+            await thumbnailExecutor.progressSubject.receive(on: RunLoop.main)
                 .sink { [weak self] progressNumber in
                     guard let self else {return}
                     UIView.animate(withDuration: 0.2) {
@@ -70,11 +70,11 @@ final class PhotoSelectionViewController: LoadingVC{
                         self.pregress.progress = progressNumber
                     }
                 }.store(in: &cancellable)
-            videoExecutor.progressSubject.receive(on: RunLoop.main)
+            await videoExecutor.progressSubject.receive(on: RunLoop.main)
                 .sink { [weak self] progressNumber in
                     self?.loadingProgressView?.progress = progressNumber
                 }.store(in: &cancellable)
-            videoExecutor.videosSubject.sink { [weak self] avassetContainers in
+            await videoExecutor.videosSubject.sink { [weak self] avassetContainers in
                 let orderIdentifiers = self?.vm.selectImageContainerSubject.value.compactMap({$0}).map(\.id)
                 guard let orderIdentifiers, orderIdentifiers.count == self?.frameCount else {
                     fatalError("왜 여기 있지?")
@@ -157,8 +157,7 @@ final class PhotoSelectionViewController: LoadingVC{
         pregress.isHidden = true
         selectDoneBtn.action = { [weak self] in
             guard let self else {return}
-            presentLoadingAlert(message: "라이브 포토 영상으로 변환 중...", cancelAction: { [weak self] in
-            })
+            presentLoadingAlert(message: "라이브 포토 영상으로 변환 중...", cancelAction: {})
             Task{
                 await self.videoExecutor.run()
             }
@@ -207,7 +206,6 @@ extension PhotoSelectionViewController:PHPickerViewControllerDelegate{
         }
         self.dismiss(animated: true){[weak self] in
             if assets.count == 0{
-                print(self?.isPagingEnabled)
                 if !(self?.isPagingEnabled ?? false){
                     self?.navigationController?.popViewController(animated: true)
                 }

--- a/LiveFourCut/LiveFourCut/Views/Utils/Executors/VideoExecutor.swift
+++ b/LiveFourCut/LiveFourCut/Views/Utils/Executors/VideoExecutor.swift
@@ -50,7 +50,7 @@ actor VideoExecutor{
                     self.minDuration = min(secondsLength,self.minDuration)
                     let cnt = self.fetchItems.count
                     
-                    let tempFileURL = try await self.moveAssetDirToTempDir(urlAsset: urlAsset)
+                    let tempFileURL = try await self.moveAssetDirToTempDir(urlAsset: &urlAsset)
                     
                     self.fetchItems.append(AVAssetContainer(id: asset.localIdentifier, idx: cnt, minDuration: 1000,
                                                             originalAssetURL: tempFileURL.absoluteString))
@@ -77,7 +77,7 @@ actor VideoExecutor{
 }
 
 extension VideoExecutor {
-    nonisolated fileprivate func moveAssetDirToTempDir(urlAsset: AVURLAsset) async throws -> URL{
+    nonisolated fileprivate func moveAssetDirToTempDir(urlAsset: inout AVURLAsset) async throws -> URL{
         let lastComponent = urlAsset.url.lastPathComponent
         let tempFileURL = FileManager().temporaryDirectory.appendingPathComponent(lastComponent)
         if FileManager.default.fileExists(atPath: tempFileURL.path()) {

--- a/LiveFourCut/LiveFourCut/Views/Utils/Executors/VideoExecutor.swift
+++ b/LiveFourCut/LiveFourCut/Views/Utils/Executors/VideoExecutor.swift
@@ -9,12 +9,17 @@ import Foundation
 import Combine
 import Photos
 import UIKit
-
+enum VideoExecutorErrors: Error, Sendable{
+    case failedSavedTempDirectory
+    case fetchFailed
+    
+}
 actor VideoExecutor{
     let videosSubject: PassthroughSubject<[AVAssetContainer],Never> = .init()
     let progressSubject:PassthroughSubject<Float,Never> = .init()
     private(set) var minDuration:Float = 1000
     private var result: PHFetchResult<PHAsset>!
+    
     private var counter: Int = -1{
         didSet{
             guard counter == 0 else {return}
@@ -38,18 +43,22 @@ actor VideoExecutor{
             let convertedIdentifier = asset.localIdentifier.replacingOccurrences(of: "/", with: "_")
             Task{
                 do{
-                    let urlAsset:AVURLAsset = try await asset.convertToAVURLAsset()
+                    var urlAsset:AVURLAsset = try await asset.convertToAVURLAsset()
                     let value:Float = (try? await Float(urlAsset.load(.duration).value)) ?? 1 // 여기 에러 처리 필요함
                     let timeScale: Float = (try? await Float(urlAsset.load(.duration).timescale)) ?? 1 // 여기 에러 처리 필요함
                     let secondsLength = value / timeScale
                     self.minDuration = min(secondsLength,self.minDuration)
                     let cnt = self.fetchItems.count
                     
-                    self.fetchItems.append(AVAssetContainer(id: asset.localIdentifier, idx: cnt, minDuration: 1000, originalAssetURL: urlAsset.url.absoluteString))
+                    let tempFileURL = try await self.moveAssetDirToTempDir(urlAsset: urlAsset)
+                    
+                    self.fetchItems.append(AVAssetContainer(id: asset.localIdentifier, idx: cnt, minDuration: 1000,
+                                                            originalAssetURL: tempFileURL.absoluteString))
+                    
                     self.counter -= 1
                     self.progressSubject.send(min(1, Float(resultCount - self.counter) / Float(2 * resultCount)))
                 }catch{
-                    fatalError("무슨 문제야")
+                    throw VideoExecutorErrors.fetchFailed
                 }
             }
         }
@@ -67,8 +76,41 @@ actor VideoExecutor{
     }
 }
 
+extension VideoExecutor {
+    nonisolated fileprivate func moveAssetDirToTempDir(urlAsset: AVURLAsset) async throws -> URL{
+        let lastComponent = urlAsset.url.lastPathComponent
+        let tempFileURL = FileManager().temporaryDirectory.appendingPathComponent(lastComponent)
+        if FileManager.default.fileExists(atPath: tempFileURL.path()) {
+            try? FileManager.default.removeItem(at: tempFileURL)
+        }
+        
+        guard let exportSession = AVAssetExportSession(asset: urlAsset,
+                                                       presetName: AVAssetExportPresetHighestQuality) else {
+            throw VideoExecutorErrors.failedSavedTempDirectory
+        }
+        
+        exportSession.outputURL = tempFileURL
+        exportSession.outputFileType = .mov  // MP4 형식으로 저장
+        if #available(iOS 18.0, *) {
+            do {
+                try await exportSession.export(to: tempFileURL, as: .mov)
+            } catch {
+                throw VideoExecutorErrors.failedSavedTempDirectory
+            }
+        } else {
+            await exportSession.export()
+            switch exportSession.status {
+                case .cancelled,.completed: break
+                case .unknown, .waiting, .exporting, .failed: throw VideoExecutorErrors.failedSavedTempDirectory
+                @unknown default: throw VideoExecutorErrors.failedSavedTempDirectory
+            }
+        }
+        return tempFileURL
+    }
+}
+
 extension FileManager{
-    func tempFileExist(fileName:String) -> Bool{
+    func tempFileExist(fileName:String) async throws-> Bool{
         let newFileURL = self.temporaryDirectory.appendingPathComponent(fileName)
         return self.fileExists(atPath: newFileURL.absoluteString)
     }


### PR DESCRIPTION
# 📋 설명
> 미리보기에 AVPlayer가 재생할 수 없는 문제가 발생했습니다.
iOS 18 부터 Sandbox 정책이 강화된 것 같습니다.
기존 AVPlayer에서 사용자 앨범에 위치한 미디어를 재생했지만 이 미디어를 임시 폴더에 저장한 후, 재생시킵니다.

 
# ✅ 체크리스트
> 구현해야하는 이슈 체크리스트를 적어주세요.

- [x] 임시 폴더에 영상 미디어를 저장시키고 이를 재생합니다.
- iOS 18에 대응되는 최신 메서드를 적용합니다

https://github.com/user-attachments/assets/05037ac8-7bb8-49a1-b472-8f302a5b3c06
