### PR TITLE
[PR#5] 영상 병합 로직 오류, 갤러리 에셋 패치 오류 수정

### DIFF
--- a/LiveFourCut/LiveFourCut.xcodeproj/project.pbxproj
+++ b/LiveFourCut/LiveFourCut.xcodeproj/project.pbxproj
@@ -792,8 +792,8 @@
 				INFOPLIST_FILE = LiveFourCut/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Live4Cut;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 추가 좀";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 좀";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "앱에서 사진을 내보내기 위해 접근이 필요합니다";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앱에서 사진을 가져오기 위해 접근이 필요합니다";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleDarkContent;
@@ -829,8 +829,8 @@
 				INFOPLIST_FILE = LiveFourCut/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Live4Cut;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 추가 좀";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 좀";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "앱에서 사진을 내보내기 위해 접근이 필요합니다";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앱에서 사진을 가져오기 위해 접근이 필요합니다";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleDarkContent;

--- a/LiveFourCut/LiveFourCut/Info.plist
+++ b/LiveFourCut/LiveFourCut/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key></key>
+	<key>CFBundleGetInfoString</key>
 	<string></string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/LiveFourCut/LiveFourCut/Services/FrameService.swift
+++ b/LiveFourCut/LiveFourCut/Services/FrameService.swift
@@ -32,8 +32,7 @@ final class FrameGenerator:FrameServiceProtocol{
             for offset in 0..<frameCount {
                 let singleFrameImages = (0..<groupCount).map{ groupImage[$0][offset] }
                 taskGroup.addTask {
-                    let reduceImage = try! self.reduce(images: singleFrameImages, spacing: 10)
-
+                    let reduceImage = try! self.reduce(images: singleFrameImages, spacing: 4)
                     return (offset,reduceImage)
                 }
             }
@@ -55,7 +54,8 @@ extension FrameGenerator{
             let flippedImg = try! $0.flipImageHorizontal()!
             let (height,width) = (CGFloat(flippedImg.height),CGFloat(flippedImg.width))
             let centerCropSize = CGRect.cropFromCenter(width: width, height: height,ratio: frameTargetSize.ratio)
-            return flippedImg.cropping(to: centerCropSize)!.makeRoundedCorner(radius: frameCornerRadius  * centerCropSize.width / frameTargetSize.width)!
+            return flippedImg.cropping(to: centerCropSize)!
+//                .makeRoundedCorner(radius: frameCornerRadius  * centerCropSize.width / frameTargetSize.width)!
         }
         let nW = 0.5 * frameTargetSize.width - 1.5 * spacing
         let nH = 0.5 * frameTargetSize.height - 1.5 * spacing
@@ -100,10 +100,13 @@ extension CGContext{
         let bytesPerRow = cgImage.bytesPerRow
         let colorSpace = cgImage.colorSpace
         let bitmapInfo = cgImage.bitmapInfo
-        return CGContext(data: nil, width: width, height: height, bitsPerComponent: bitsPerComponent,
-                                      bytesPerRow: bytesPerRow,
-                                      space: colorSpace!,
-                                      bitmapInfo: bitmapInfo.rawValue)
+        return CGContext(data: nil,
+                         width: width,
+                         height: height,
+                         bitsPerComponent: bitsPerComponent,
+                         bytesPerRow: bytesPerRow,
+                         space: colorSpace!,
+                         bitmapInfo: bitmapInfo.rawValue)
     }
 }
 extension CGSize{

--- a/LiveFourCut/LiveFourCut/Services/FrameService.swift
+++ b/LiveFourCut/LiveFourCut/Services/FrameService.swift
@@ -110,5 +110,5 @@ extension CGContext{
     }
 }
 extension CGSize{
-    var ratio:CGFloat{ self.height / self.width }
+    var ratio:CGFloat{ self.width / self.height }
 }

--- a/LiveFourCut/LiveFourCut/Services/FrameService.swift
+++ b/LiveFourCut/LiveFourCut/Services/FrameService.swift
@@ -23,8 +23,8 @@ protocol FrameServiceProtocol{
 }
 final class FrameGenerator:FrameServiceProtocol{
     var frameType:FrameType = .basic2x2
-    var frameTargetSize: CGSize = .init(width: 300, height: 400)
-    var frameCornerRadius: CGFloat = 40
+    var frameTargetSize: CGSize = .init(width: 300, height: 300 * 1.77)
+    var frameCornerRadius: CGFloat = 0
     func groupReduce(groupImage: [[CGImage]],spacing: CGFloat) async throws -> [CGImage]{
         let frameCount = groupImage.first!.count
         let groupCount = groupImage.count
@@ -65,7 +65,7 @@ extension FrameGenerator{
         let rdRect = CGRect.init(x: nW + 2 * spacing, y: nH + 2 * spacing, width: nW, height: nH)
         let render = UIGraphicsImageRenderer(size: frameTargetSize)
         let imageData = render.image { context in
-            context.cgContext.setFillColor(UIColor.blue.cgColor)
+            context.cgContext.setFillColor(UIColor.black.cgColor)
             context.cgContext.beginPath()
             let roundedPath2 = CGPath.init(roundedRect: .init(origin: .zero, size: frameTargetSize),
                                            cornerWidth: frameCornerRadius, cornerHeight: frameCornerRadius, transform: nil)

--- a/LiveFourCut/LiveFourCut/Services/LPtoAVService.swift
+++ b/LiveFourCut/LiveFourCut/Services/LPtoAVService.swift
@@ -29,6 +29,10 @@ actor LPtoAVService: NSObject{
     }
     var minDuration:Float = 1000
     let wow: PassthroughSubject<[AVURLAsset],Never> = .init()
+    
+    private let videoManagerManager: PHCachingImageManager = .init()
+    private var fetchAssets:[PHAsset] = []
+    
     override init() {
         super.init()
     }

--- a/LiveFourCut/LiveFourCut/Services/PHAssetExtensions.swift
+++ b/LiveFourCut/LiveFourCut/Services/PHAssetExtensions.swift
@@ -18,9 +18,11 @@ extension PHAsset{
                 let image = self!.coreDownSample(resource: imageSource,size: size)
                 continuation.resume(returning: image)
             }
+            
         }
     }
     private func coreDownSample(resource:CGImageSource,size:CGSize? = nil) -> UIImage{
+        
         let scale = UIScreen.main.scale
         let screenSize = UIScreen.main.bounds
         let maxPixel = if let size{
@@ -35,6 +37,33 @@ extension PHAsset{
             kCGImageSourceThumbnailMaxPixelSize: maxPixel
         ] as CFDictionary
         return if let downSampledImage = CGImageSourceCreateThumbnailAtIndex(resource, 0, downSampleOptions){
+            UIImage(cgImage: downSampledImage)
+        }else{
+            UIImage(resource: .hanroro1)
+        }
+    }
+}
+extension UIImage{
+    private func coreDownSample(size:CGSize? = nil) -> UIImage{
+        let imageSourceOption = [kCGImageSourceShouldCache: false] as CFDictionary
+        let data = self.pngData() as! CFData
+        let imageSource: CGImageSource = CGImageSourceCreateWithData(data, imageSourceOption)!
+//        CGImageSourceCreateWithURL(imageURL as CFURL, imageSourceOption)!
+        
+        let scale = UIScreen.main.scale
+        let screenSize = UIScreen.main.bounds
+        let maxPixel = if let size{
+             max(size.width, size.height) * scale
+        }else{
+            max(screenSize.width,screenSize.height) * scale
+        }
+        let downSampleOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel
+        ] as CFDictionary
+        return if let downSampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downSampleOptions){
             UIImage(cgImage: downSampledImage)
         }else{
             UIImage(resource: .hanroro1)

--- a/LiveFourCut/LiveFourCut/Test/VideoFrameDividerScene/VideoFrameDividerScene.swift
+++ b/LiveFourCut/LiveFourCut/Test/VideoFrameDividerScene/VideoFrameDividerScene.swift
@@ -123,18 +123,20 @@ extension UIImage{
 }
 extension CGRect{
     static func cropFromCenter(width:CGFloat,height:CGFloat,ratio targetRatio:CGFloat = 1) -> Self{
+        let currentRatio = width / height
         var yOffset:CGFloat = 0
         var xOffset:CGFloat = 0
-        var height:CGFloat = height
-        var width:CGFloat = width
-        if width < height{
-            yOffset = (height - width * targetRatio)  * 0.5
-            height = width * targetRatio
+        var cropHeight:CGFloat = height
+        var cropWidth:CGFloat = width
+        if currentRatio > targetRatio{
+            cropWidth = height * targetRatio
+            xOffset = (width - cropWidth) * 0.5
+            
         }else{
-            xOffset = (width - height * targetRatio) * 0.5
-            width = height * targetRatio
+            cropHeight = width / targetRatio
+            yOffset = (height - cropHeight) * 0.5
         }
-        let cropSize = CGRect(x: xOffset, y: yOffset, width: width, height: height)
+        let cropSize = CGRect(x: xOffset, y: yOffset, width: cropWidth, height: cropHeight)
         return cropSize
     }
 }

--- a/LiveFourCut/LiveFourCut/Views/FourCutPreScene/FourCutPreViewController.swift
+++ b/LiveFourCut/LiveFourCut/Views/FourCutPreScene/FourCutPreViewController.swift
@@ -105,7 +105,7 @@ final class FourCutPreViewController: BaseVC{
                 print("minDuration \(self.minDuration)")
                 do{
                     var frameImages = try await self.extractService.extractFrameImages()
-                    var imgDatas:[CGImage] = try await self.frameService.groupReduce(groupImage: frameImages, spacing: 10)
+                    var imgDatas:[CGImage] = try await self.frameService.groupReduce(groupImage: frameImages, spacing: 4)
                     print("추출은 된다. \(frameImages.first?.count)")
                     print("감소는 된다. \(imgDatas.count)")
                     frameImages = [] // 함수 사용 후 스택에서 제거해야한다.

--- a/LiveFourCut/LiveFourCut/Views/SharingViewController.swift
+++ b/LiveFourCut/LiveFourCut/Views/SharingViewController.swift
@@ -43,7 +43,8 @@ class SharingViewController: BaseVC {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.playerLayer?.frame = view.bounds
-        self.playerLayer?.videoGravity = .resize
+        self.playerLayer?.frame = self.videoFrameView.bounds
+        self.playerLayer?.videoGravity = .resizeAspectFill
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -100,7 +101,6 @@ class SharingViewController: BaseVC {
     }
     override func configureView() {
         super.configureView()
-
         self.shareBtn.addAction(.init(handler: {[weak self] action in
             guard let self else {return}
             guard let url = videoURL else { return }
@@ -119,7 +119,7 @@ class SharingViewController: BaseVC {
         self.queuePlayer.items()
         self.looper = AVPlayerLooper(player: queuePlayer,templateItem: playerItem)
         self.playerLayer = playerLayer
-        
+        self.playerLayer?.videoGravity = .resizeAspectFill
         self.videoFrameView.backgroundColor = .white
         self.videoFrameView.layer.masksToBounds = true
         self.videoFrameView.layer.addSublayer(playerLayer)

--- a/LiveFourCut/LiveFourCut/Views/Utils/Executors/ThumbnailExecutor.swift
+++ b/LiveFourCut/LiveFourCut/Views/Utils/Executors/ThumbnailExecutor.swift
@@ -13,14 +13,35 @@ actor ThumbnailExecutor{ // Actor는 상속이 가능하다
     let thumbnailsSubject: PassthroughSubject<[ImageContainer],Never> = .init()
     let progressSubject:PassthroughSubject<Float,Never> = .init()
     private var result: PHFetchResult<PHAsset>!
+    private let imageManager: PHCachingImageManager = .init()
     private var counter: Int = -1{
         didSet{
             guard counter == 0 else {return}
             thumbnailsSubject.send(fetchItems)
             fetchItems.removeAll()
+            fetchAssets.removeAll()
         }
     }
     private var fetchItems:[ImageContainer] = []
+    private var fetchAssets:[PHAsset] = []{
+        didSet{
+            guard counter == fetchAssets.count else { return }
+            Task {
+                let resultCount = self.fetchAssets.count
+                for asset in fetchAssets {
+                    fetchImage(phAsset: asset,
+                               size: .init(width: 3 * 120, height: 3 * 120 * 1.77),
+                               contentMode: .aspectFill) { image in
+                        let count = self.fetchItems.count
+                        self.fetchItems.append(ImageContainer(id: asset.localIdentifier, image: image, idx: count))
+                        self.counter -= 1
+                        self.progressSubject.send(min(1,(Float(resultCount - self.counter) / Float(resultCount))))
+                    }
+                }
+            }
+        }
+    }
+    
     func setFetchResult(result: PHFetchResult<PHAsset>) async{
         self.result = result
     }
@@ -29,19 +50,39 @@ actor ThumbnailExecutor{ // Actor는 상속이 가능하다
         fetchItems.removeAll()
         let resultCount = result.count
         self.progressSubject.send(0)
-        result.enumerateObjects(options:.concurrent) { asset, _, _ in
-            Task{
-                do{
-                    let image = try await asset.convertToUIImage(size: .init(width: 120, height: 120 * 1.3333)) 
-                    let count = self.fetchItems.count
-                    self.fetchItems.append(ImageContainer(id: asset.localIdentifier, image: image, idx: count))
-                    self.counter -= 1
-                    self.progressSubject.send(min(1,(Float(resultCount - self.counter) / Float(resultCount))))
-                }catch{
-                    fatalError("무슨 문제야")
-                }
-            }
+    
+        result.enumerateObjects(options: .concurrent) {  asset, _, _ in
+            self.fetchAssets.append(asset)
+//            Task{
+//                do{
+//                
+////                    let image = try await asset.convertToUIImage(size: .init(width: 120, height: 120 * 1.3333))
+////                    let count = self.fetchItems.count
+////                    self.fetchItems.append(ImageContainer(id: asset.localIdentifier, image: image, idx: count))
+////                    self.counter -= 1
+////                    self.progressSubject.send(min(1,(Float(resultCount - self.counter) / Float(resultCount))))
+//                }catch{
+//                    fatalError("무슨 문제야")
+//                }
+//            }
         }
+    }
+    private func fetchImage(
+        phAsset: PHAsset,
+        size: CGSize,
+        contentMode: PHImageContentMode,
+        completion: @escaping (UIImage) -> Void
+    ) {
+        let options = PHImageRequestOptions()
+        options.isNetworkAccessAllowed = true // iCloud
+        options.deliveryMode = .highQualityFormat
+        
+        imageManager.requestImage(for: phAsset,targetSize: size,contentMode: contentMode, options: options,
+            resultHandler: { image, _ in
+                guard let image else { return }
+                completion(image)
+            }
+        )
     }
 }
 


### PR DESCRIPTION
# 📋 설명
> 사용자가 네컷 이미지를 넣는 프레임이 변경되어 이에 맞도록 병합 프레임을 재조정합니다.
> 아이클라우드에 있는 갤러리에 사진을 가져올 경우 실패하는 오류가 발생했습니다. 이를 수정합니다.

 
# ✅ 체크리스트
> 구현해야하는 이슈 체크리스트를 적어주세요.

- [x] 병합 프레임의 Corner Radius를 제거합니다.
- [x] 병합 프레임의 비율을 변경합니다.
- [x] 병합 프레임의 색상을 변경합니다.
- [x] 썸네일 이미지를 가져올 때 발생하는 오류를 수정합니다.
- [x] 라이브 포토 영상을 가져올 때 발생하는 오류를 수정합니다.


------
갤러리 fetch 오류 -> 갤러리에 사진을 가져올 때의 로직을 Apple의 Photos API를 적극 사용하여 해결했습니다.
'기존 방식'
`
return try await withCheckedThrowingContinuation { [weak self] continuation in
    phAsset?.requestContentEditingInput(with: nil) { input, info in
        continuation.resume(returning: image)
    }
}
`
방식으로 phAsset을 이미지로 바꾸는 방식이었습니다. 이 로직에서 `CONTINUATION MISUSE: leaked its continuation`이 계속 발생함
`PHCachingImageManager`와 `PHAssetResource`를 적극 도입한 방법으로 해결

# 🖼️ 스크린 샷
<img src="https://github.com/user-attachments/assets/0b00f75f-adae-4eac-9c15-98b233d2b86f" width="200">
